### PR TITLE
package.json: update `style-deps` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "once": "~1.3.0",
-    "style-deps": "^1.3.0",
+    "style-deps": "^2.0.0",
     "subarg": "0.0.1",
     "xtend": "~2.1.2",
     "style-resolve": "0.0.0"


### PR DESCRIPTION
Bumps the style-deps version to newly released `2.0.0`. Thanks!
