### PR TITLE
docs: s/className/class/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const prefix = sf`
 `
 
 const tree = hx`
-  <section className=${prefix}>
+  <section class=${prefix}>
     <h1>My beautiful, centered title</h1>
   </section>
 `
@@ -84,7 +84,7 @@ const prefix = sf`
 `
 
 const tree = hx`
-  <section className=${prefix}>
+  <section class=${prefix}>
     <h1>My beautiful, centered title</h1>
   </section>
 `
@@ -104,7 +104,7 @@ const hx = hyperx(vdom.h)
 const prefix = sf('./my-styles.css')
 
 const tree = hx`
-  <section className=${prefix}>
+  <section class=${prefix}>
     <h1>My beautiful, centered title</h1>
   </section>
 `
@@ -174,7 +174,7 @@ const prefix = sf`
 `
 
 const tree = hx`
-  <section className=${prefix}>
+  <section class=${prefix}>
     <h1>My beautiful, centered title</h1>
   </section>
 `


### PR DESCRIPTION
`hyperx` [now supports `class` in addition to `className`](https://github.com/substack/hyperx/pull/22); I think using `class` here plays well into the idea that _it's just HTML and CSS_. Thanks!