### PR TITLE
test: add empty string test

### DIFF
--- a/test/fixtures/prefix-empty-source.js
+++ b/test/fixtures/prefix-empty-source.js
@@ -1,0 +1,3 @@
+const sf = require('sheetify')
+
+sf``

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -103,4 +103,24 @@ test('prefix', function (t) {
       return ws
     }
   })
+
+  t.test('should return a prefix when an empty string is passed', function (t) {
+    t.plan(1)
+
+    const ws = concat(function (buf) {
+      const res = String(buf).trim()
+      t.equal(res, '', 'css is equal')
+    })
+
+    const bOpts = { browserField: false }
+    const bpath = path.join(__dirname, 'fixtures/prefix-empty-source.js')
+    browserify(bpath, bOpts)
+      .transform(transform)
+      .plugin('css-extract', { out: outFn })
+      .bundle()
+
+    function outFn () {
+      return ws
+    }
+  })
 })


### PR DESCRIPTION
Adds a failing test for when an empty string is passed. It's a bit annoying
when this happens. Haven't been able to find a fix for it quite yet. Feel free
to pull this branch and resubmit a PR with a patch on top. Thanks!
