### PR TITLE
Make it clearer what `:host` does

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,25 @@ const tree = hx`
 document.body.appendChild(vdom.create(tree))
 ```
 
+By using `:host` we are able to provide styles for the parent element:
+
+```css
+._60ed23ec9f {
+  background-color: blue;
+}
+
+._60ed23ec9f > h1 {
+  text-decoration: underline;
+}
+```
+
+```html
+<section class="_60ed23ec9f">
+  <h1>My beautiful, centered title</h1>
+</style>
+```
+
+
 ## External files
 To include an external CSS file you can pass a path to sheetify as
 `sheetify('./my-file.css')`:


### PR DESCRIPTION
I wasn't sure what the `:host` pseudo-selector was for until I dug through the closed issues.  Googling it brings up the shadow DOM and styling _it's_ root element but my brain was all "I'm not using the shadow DOM, maybe that's what this for? IDK".

Then I just played with it in the code and generated a page and realized it was exactly what I was looking for.  An example of the transformed CSS would go a long way to showing how that is uses.