### PR TITLE
Error handling for postcss.process and running falafel fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,8 +38,14 @@ function parseCss (src, filename, prefix, options, done) {
     if (err) return done(err)
     var p = postcss()
     if (options.global !== true) p = p.use(cssPrefix('.' + prefix))
-    css = p.process(css).toString()
-    return done(null, css, prefix)
+
+    try {
+      css = p.process(css).toString()
+
+      return done(null, css, prefix)
+    } catch (e) {
+      return done(e)
+    }
   })
 
   // apply transforms to a string of css,

--- a/transform.js
+++ b/transform.js
@@ -51,10 +51,16 @@ function transform (filename, options) {
     // but tough times call for tough measure. Please don't
     // judge us too harshly, we'll work on perf ✨soon✨ -yw
     const nodes = []
-    var mname = null
     const src = Buffer.concat(bufs).toString('utf8')
-    const tmpAst = falafel(src, { ecmaVersion: 6 }, identifyModuleName)
-    const ast = falafel(tmpAst.toString(), { ecmaVersion: 6 }, extractNodes)
+    var mname = null
+    var ast
+
+    try {
+      const tmpAst = falafel(src, { ecmaVersion: 6 }, identifyModuleName)
+      ast = falafel(tmpAst.toString(), { ecmaVersion: 6 }, extractNodes)
+    } catch (err) {
+      return self.emit('error', err)
+    }
 
     // transform all detected nodes and
     // close stream when done


### PR DESCRIPTION
This pull request will fix #72 

Also noticed that there was no error handling for when `falafel` was being run. So essentially for the end user using `sheetify` with `budo` if you made a JS syntax error it would halt `budo`.