### PR TITLE
Trim `src` to avoid string padding errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ function sheetify (src, filename, options, done) {
   // handle tagged template calls directly from Node
   if (Array.isArray(src)) src = src.join('')
   assert.equal(typeof src, 'string', 'src must be a string')
+  src = src.trim()
 
   const prefix = '_' + crypto.createHash('md5')
     .update(src)


### PR DESCRIPTION
I found a situation where

```js
var prefix = sf`
  :host {}
`
```

resulted in different prefixes when generated in node & later generated using browserify & the sheetify transform.

Somehow the prefix created with node had whitespace (the newline after the `sf` call) that wasn't present in the prefix created with browserify & the transform.

This is a quick fix to ensure there's no extra whitespace around the `src`.