### PR TITLE
deps: fix peerdep in v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   ],
   "dependencies": {
     "falafel": "^1.2.0",
+    "insert-css": "^0.2.0",
     "is-stream": "^1.0.1",
     "map-limit": "0.0.1",
     "postcss": "^5.0.10",


### PR DESCRIPTION
As per https://codingwithspike.wordpress.com/2016/01/21/dealing-with-the-deprecation-of-peerdependencies-in-npm-3/ closes #68. Thanks!

cc/ @ahdinosaur @hughsk 