### PR TITLE
emit file event on imports. Fix #55

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -114,6 +114,7 @@ function transform (filename, options) {
         var resolvePath = cssResolve(node.arguments[0].value, {
           basedir: path.dirname(filename)
         })
+        self.emit('file', resolvePath)
       } catch (err) {
         return self.emit('error', err)
       }


### PR DESCRIPTION
You'll see I didn't add a test because I thought it was simply too much work to do for a minor change (with this simple change we should check that a modification in a CSS file updates the bundle just fine). I just can confirm watch mode works now from my own manual tests in the browser.