### PR TITLE
pass JSON files through

### DIFF
--- a/test/fixtures/example.json
+++ b/test/fixtures/example.json
@@ -1,0 +1,1 @@
+{ "same": "as it ever was" }

--- a/test/json.js
+++ b/test/json.js
@@ -1,0 +1,20 @@
+const test = require('tape')
+const join = require('path').join
+const browserify = require('browserify')
+
+const transform = require('../transform')
+
+test('JSON files', function (t) {
+  t.plan(2)
+
+  browserify()
+    .add(join(__dirname, 'fixtures', './example.json'))
+    .transform(transform)
+    .bundle(function (err, code) {
+      if (err) return t.end(err)
+      code = String(code)
+
+      t.assert(code.includes('same'), 'preserves key')
+      t.assert(code.includes('as it ever was'), 'preserves value')
+    })
+})

--- a/transform.js
+++ b/transform.js
@@ -16,6 +16,8 @@ module.exports = transform
 // inline sheetify transform for browserify
 // obj -> (str, opts) -> str
 function transform (filename, options) {
+  if (/\.json$/i.test(filename)) return through()
+
   const opts = xtend(options || {
     basedir: process.cwd(),
     use: [],


### PR DESCRIPTION
before this commit, `require`-ing a JSON file causes

```
SyntaxError: Unexpected token ...
```

this commit

- adds a test for this situation, and
- checks filenames coming in and passes `.json` files through without transformation.
  (`through2` without arguments creates a pass-through stream)

copypasta from: https://github.com/yoshuawuyts/es2020/pull/13