### PR TITLE
bump insert-css

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "falafel": "^1.2.0",
-    "insert-css": "^0.2.0",
+    "insert-css": "^1.0.0",
     "is-stream": "^1.0.1",
     "map-limit": "0.0.1",
     "postcss": "^5.0.10",
@@ -34,7 +34,7 @@
     "xtend": "^4.0.1"
   },
   "peerDependencies": {
-    "insert-css": "^0.2.0"
+    "insert-css": "^1.0.0"
   },
   "devDependencies": {
     "browserify": "^13.0.0",
@@ -42,7 +42,7 @@
     "css-extract": "^1.0.0",
     "css-type-base": "^1.0.2",
     "dependency-check": "^2.5.1",
-    "insert-css": "^0.2.0",
+    "insert-css": "^1.0.0",
     "istanbul": "^0.3.19",
     "jsdom": "^8.0.2",
     "npm-check-updates": "^2.2.0",


### PR DESCRIPTION
I'm still curious why it's listed in all `dependencies`, `devDependencies` and `peerDependencies`. 