### PR TITLE
test: upgrade css-extract

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "browserify": "^13.0.0",
     "concat-stream": "^1.5.1",
-    "css-extract": "^1.0.0",
+    "css-extract": "^1.1.1",
     "css-type-base": "^1.0.2",
     "dependency-check": "^2.5.1",
     "insert-css": "^0.2.0",


### PR DESCRIPTION
continuation of https://github.com/stackcss/sheetify/issues/77. without this, tests are still using old version of `css-extract` before https://github.com/stackcss/css-extract/pull/6.