### PR TITLE
Fix prefix calculation from node

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function sheetify (src, filename, options, done) {
     .slice(0, 8)
 
   // only parse if in a browserify transform
-  if (filename) parseCss(src, filename, prefix, options, done)
+  if (filename) parseCss(src.trim(), filename, prefix, options, done)
 
   return prefix
 }

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const fs = require('fs')
 const path = require('path')
 
 module.exports = sheetify
+module.exports.getPrefix = getPrefix
 
 // transform css
 // (str, str, obj?, fn) -> str
@@ -27,21 +28,25 @@ function sheetify (src, filename, options, done) {
      // module or file name via tagged template call w or w/out options
     const callerDirname = path.dirname(stackTrace.get()[1].getFileName())
     const resolved = cssResolve(src, { basedir: callerDirname })
-    css = fs.readFileSync(resolved, 'utf8').trim()
+    css = fs.readFileSync(resolved, 'utf8')
   } else {
     // it better be some css
     css = src
   }
 
-  css = css.trim()
-  const prefix = '_' + crypto.createHash('md5')
-    .update(css)
-    .digest('hex')
-    .slice(0, 8)
+  const prefix = getPrefix(css)
 
   // only parse if in a browserify transform
   if (typeof filename === 'string') parseCss(src, filename, prefix, options, done)
 
+  return prefix
+}
+
+function getPrefix (css) {
+  const prefix = '_' + crypto.createHash('md5')
+    .update(css.trim())
+    .digest('hex')
+    .slice(0, 8)
   return prefix
 }
 

--- a/index.js
+++ b/index.js
@@ -23,8 +23,8 @@ function sheetify (src, filename, options, done) {
 
   // Ensure prefix is always correct when run from inside node
   let css
-  if (!isTemplate && !filename) {
-     // module or file name via tagged template call
+  if (!isTemplate && (!filename || typeof filename === 'object')) {
+     // module or file name via tagged template call w or w/out options
     const callerDirname = path.dirname(stackTrace.get()[1].getFileName())
     const resolved = cssResolve(src, { basedir: callerDirname })
     css = fs.readFileSync(resolved, 'utf8').trim()
@@ -40,7 +40,7 @@ function sheetify (src, filename, options, done) {
     .slice(0, 8)
 
   // only parse if in a browserify transform
-  if (filename) parseCss(src, filename, prefix, options, done)
+  if (typeof filename === 'string') parseCss(src, filename, prefix, options, done)
 
   return prefix
 }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function sheetify (src, filename, options, done) {
   const isTemplate = Array.isArray(src)
   if (isTemplate) src = src.join('')
   assert.equal(typeof src, 'string', 'src must be a string')
+  src = src.trim()
 
   // Ensure prefix is always correct when run from inside node
   let css
@@ -26,7 +27,7 @@ function sheetify (src, filename, options, done) {
      // module or file name via tagged template call
     const callerDirname = path.dirname(stackTrace.get()[1].getFileName())
     const resolved = cssResolve(src, { basedir: callerDirname })
-    css = fs.readFileSync(resolved, 'utf8')
+    css = fs.readFileSync(resolved, 'utf8').trim()
   } else {
     // it better be some css
     css = src
@@ -39,7 +40,7 @@ function sheetify (src, filename, options, done) {
     .slice(0, 8)
 
   // only parse if in a browserify transform
-  if (filename) parseCss(src.trim(), filename, prefix, options, done)
+  if (filename) parseCss(src, filename, prefix, options, done)
 
   return prefix
 }

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function sheetify (src, filename, options, done) {
   src = src.trim()
 
   // Ensure prefix is always correct when run from inside node
-  let css
+  var css
   if (!isTemplate && (!filename || typeof filename === 'object')) {
      // module or file name via tagged template call w or w/out options
     const callerDirname = path.dirname(stackTrace.get()[1].getFileName())

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "concat-stream": "^1.5.1",
     "css-extract": "^1.1.2",
     "css-type-base": "^1.0.2",
+    "css-wipe": "^4.2.2",
     "dependency-check": "^2.5.1",
     "insert-css": "^1.0.0",
     "istanbul": "^0.3.19",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "postcss": "^5.0.10",
     "postcss-prefix": "^1.0.3",
     "resolve": "^1.1.7",
+    "stack-trace": "0.0.9",
     "static-eval": "^0.2.4",
     "style-resolve": "^1.0.0",
     "through2": "^2.0.0",

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -4,6 +4,7 @@ const test = require('tape')
 const path = require('path')
 const fs = require('fs')
 const vm = require('vm')
+const cssResolve = require('style-resolve').sync
 
 const transform = require('../transform')
 const sheetify = require('..')
@@ -11,8 +12,26 @@ const sheetify = require('..')
 test('prefix', function (t) {
   t.test('should return a prefix when called in Node', function (t) {
     t.plan(1)
-    const prefix = sheetify('.foo { color: blue; }')
-    t.equal(prefix, '_d1b3f246', 'prefix is equal')
+    const prefix = sheetify`.foo { color: blue; }`
+    const expected = sheetify.getPrefix('.foo { color: blue; }')
+    t.equal(prefix, expected, 'prefix is equal')
+  })
+
+  t.test('should return a prefix with relative path in Node', function (t) {
+    t.plan(1)
+    const expath = path.join(__dirname, 'fixtures/prefix-import-source.css')
+    const expected = sheetify.getPrefix(fs.readFileSync(expath, 'utf8'))
+    const prefix = sheetify('./fixtures/prefix-import-source.css')
+    t.equal(prefix, expected, 'prefix is equal')
+  })
+
+  t.test('should return a prefix with a module name in Node', function (t) {
+    t.plan(1)
+    const expath = cssResolve('css-wipe')
+    console.log(expath)
+    const expected = sheetify.getPrefix(fs.readFileSync(expath, 'utf8'))
+    const prefix = sheetify('css-wipe')
+    t.equal(prefix, expected, 'prefix is equal')
   })
 
   t.test('should prefix and inline template strings', function (t) {

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -28,7 +28,6 @@ test('prefix', function (t) {
   t.test('should return a prefix with a module name in Node', function (t) {
     t.plan(1)
     const expath = cssResolve('css-wipe')
-    console.log(expath)
     const expected = sheetify.getPrefix(fs.readFileSync(expath, 'utf8'))
     const prefix = sheetify('css-wipe')
     t.equal(prefix, expected, 'prefix is equal')


### PR DESCRIPTION
This fixes prefix generation when running sheetify from within node without using a browserify transform on the JS.  Prior to this fix, calling sheetify would generate hashes from module names and file paths which isn't ever a correct prefix.  

This is useful for when generating external css files for use in an electron app with unbundled JS code where you don't have access to the corrected transform output.