### PR TITLE
feat(insert): add

### DIFF
--- a/insert.js
+++ b/insert.js
@@ -1,0 +1,1 @@
+module.exports = require('insert-css')

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "falafel": "^1.2.0",
-    "insert-css": "^1.0.0",
+    "insert-css": "^2.0.0",
     "map-limit": "0.0.1",
     "postcss": "^5.0.10",
     "postcss-prefix": "^2.0.0",
@@ -33,9 +33,6 @@
     "through2": "^2.0.0",
     "xtend": "^4.0.1"
   },
-  "peerDependencies": {
-    "insert-css": "^1.0.0"
-  },
   "devDependencies": {
     "browserify": "^13.0.0",
     "codecov.io": "^0.1.6",
@@ -45,7 +42,6 @@
     "css-wipe": "^4.2.2",
     "dependency-check": "^2.5.1",
     "from2-string": "^1.1.0",
-    "insert-css": "^1.0.0",
     "istanbul": "^0.4.5",
     "jsdom": "^9.4.2",
     "npm-check-updates": "^2.2.0",

--- a/test/import.js
+++ b/test/import.js
@@ -1,5 +1,6 @@
 const browserify = require('browserify')
 const concat = require('concat-stream')
+const through = require('through2')
 const test = require('tape')
 const path = require('path')
 const fs = require('fs')
@@ -22,6 +23,13 @@ test('npm import', function (t) {
     const bpath = path.join(__dirname, 'fixtures/import-source.js')
     browserify(bpath, bOpts)
       .transform(sheetify)
+      .transform(function (file) {
+        return through(function (buf, enc, next) {
+          const str = buf.toString('utf8')
+          this.push(str.replace(/sheetify\/insert/, 'insert-css'))
+          next()
+        })
+      })
       .plugin('css-extract', { out: outFn })
       .bundle()
 

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,5 +1,6 @@
 const browserify = require('browserify')
 const concat = require('concat-stream')
+const through = require('through2')
 const test = require('tape')
 const path = require('path')
 const fs = require('fs')
@@ -23,6 +24,13 @@ test('plugins', function (t) {
     browserify(bpath, bOpts)
       .transform(sheetify, {
         use: [ [ 'sheetify-cssnext', { sourcemap: false } ] ]
+      })
+      .transform(function (file) {
+        return through(function (buf, enc, next) {
+          const str = buf.toString('utf8')
+          this.push(str.replace(/sheetify\/insert/, 'insert-css'))
+          next()
+        })
       })
       .plugin('css-extract', { out: outFn })
       .bundle()

--- a/test/prefix.js
+++ b/test/prefix.js
@@ -1,5 +1,6 @@
 const browserify = require('browserify')
 const concat = require('concat-stream')
+const through = require('through2')
 const test = require('tape')
 const path = require('path')
 const fs = require('fs')
@@ -48,6 +49,13 @@ test('prefix', function (t) {
     const bpath = path.join(__dirname, 'fixtures/prefix-inline-source.js')
     browserify(bpath, bOpts)
       .transform(transform)
+      .transform(function (file) {
+        return through(function (buf, enc, next) {
+          const str = buf.toString('utf8')
+          this.push(str.replace(/sheetify\/insert/, 'insert-css'))
+          next()
+        })
+      })
       .plugin('css-extract', { out: outFn })
       .bundle(parseBundle)
 
@@ -81,6 +89,13 @@ test('prefix', function (t) {
     const bpath = path.join(__dirname, 'fixtures/prefix-import-source.js')
     browserify(bpath, bOpts)
       .transform(transform)
+      .transform(function (file) {
+        return through(function (buf, enc, next) {
+          const str = buf.toString('utf8')
+          this.push(str.replace(/sheetify\/insert/, 'insert-css'))
+          next()
+        })
+      })
       .plugin('css-extract', { out: outFn })
       .bundle(parseBundle)
 

--- a/transform.js
+++ b/transform.js
@@ -145,7 +145,7 @@ function transform (filename, options) {
       sheetify(val.css, val.filename, val.opts, function (err, css, prefix) {
         if (err) return done(err)
         const str = [
-          "((require('insert-css')(" + JSON.stringify(css) + ')',
+          "((require('sheetify/insert')(" + JSON.stringify(css) + ')',
           ' || true) && ' + JSON.stringify(prefix) + ')'
         ].join('')
 


### PR DESCRIPTION
wip; adds `sheetify/insert` which would be used to remove the need for peer dependencies (and all its annoyances like not being installed by default and throwing warnings all over npm) - ref #105 

### todos
- [x] write implementation
- [x] fix tests (one's annoying-ish, but think regexes can help us :D)