### PR TITLE
Upgrade falafel to ^2.1.0, use ecmaVersion 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "css-modules"
   ],
   "dependencies": {
-    "falafel": "^2.0.0",
+    "falafel": "^2.1.0",
     "insert-css": "^2.0.0",
     "map-limit": "0.0.1",
     "postcss": "^5.0.10",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "css-modules"
   ],
   "dependencies": {
-    "falafel": "^1.2.0",
+    "falafel": "^2.0.0",
     "insert-css": "^2.0.0",
     "map-limit": "0.0.1",
     "postcss": "^5.0.10",

--- a/transform.js
+++ b/transform.js
@@ -55,8 +55,8 @@ function transform (filename, options) {
     }
 
     try {
-      const tmpAst = falafel(src, { ecmaVersion: 6 }, identifyModuleName)
-      ast = falafel(tmpAst.toString(), { ecmaVersion: 6 }, extractNodes)
+      const tmpAst = falafel(src, { ecmaVersion: 8 }, identifyModuleName)
+      ast = falafel(tmpAst.toString(), { ecmaVersion: 8 }, extractNodes)
     } catch (err) {
       return self.emit('error', err)
     }


### PR DESCRIPTION
Background: substack/node-browserify#1667

~~Also depends on substack/node-falafel#62 for full async/await support~~ (merged)