### PR TITLE
fix object assignments

### DIFF
--- a/test/fixtures/plugins-expected.css
+++ b/test/fixtures/plugins-expected.css
@@ -2,3 +2,7 @@
     -webkit-transform: translate(0, 0);
             transform: translate(0, 0);
   }
+._75161010 .hello,._75161010 .world {
+    -webkit-transform: translate(0, 0);
+            transform: translate(0, 0);
+  }

--- a/test/fixtures/plugins-source.js
+++ b/test/fixtures/plugins-source.js
@@ -5,4 +5,12 @@ const prefix = sf`
     transform: translate(0, 0);
   }
 `
+
+var foo = {}
+foo.bar = sf`
+  :host .hello, :host .world {
+    transform: translate(0, 0);
+  }
+`
+
 console.log(prefix)

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -28,7 +28,7 @@ test('plugins', function (t) {
       .transform(function (file) {
         return through(function (buf, enc, next) {
           const str = buf.toString('utf8')
-          this.push(str.replace(/sheetify\/insert/, 'insert-css'))
+          this.push(str.replace(/sheetify\/insert/g, 'insert-css'))
           next()
         })
       })

--- a/transform.js
+++ b/transform.js
@@ -107,16 +107,16 @@ function transform (filename, options) {
       if (node.type !== 'CallExpression') return
       if (!node.callee || node.callee.type !== 'Identifier') return
       if (node.callee.name !== mname) return
+      var pathOpts = { basedir: path.dirname(filename) }
       try {
-        var resolvePath = cssResolve(node.arguments[0].value, {
-          basedir: path.dirname(filename)
-        })
-        self.emit('file', resolvePath)
+        var resolvePath = cssResolve(node.arguments[0].value, pathOpts)
       } catch (err) {
         return self.emit('error', err)
       }
 
-      const iOpts = (node.arguments[1])
+      self.emit('file', resolvePath)
+
+      const iOpts = node.arguments[1]
         ? xtend(opts, staticEval(node.arguments[1]))
         : opts
 
@@ -149,7 +149,9 @@ function transform (filename, options) {
           ' || true) && ' + JSON.stringify(prefix) + ')'
         ].join('')
 
-        const lolSemicolon = (val.node.parent.type === 'VariableDeclarator')
+        const parentNodeType = val.node.parent.type
+        const lolSemicolon = parentNodeType === 'VariableDeclarator' ||
+          parentNodeType === 'AssignmentExpression'
           ? ''
           : ';'
         val.node.update(lolSemicolon + str)


### PR DESCRIPTION
This patch allows the following code to work:
```js
var foo = {}
foo.bar = css`.foo { color: blue }`
```