### PR TITLE
Add option to manually set prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function sheetify (src, filename, options, done) {
     css = src
   }
 
-  const prefix = getPrefix(css)
+  const prefix = options.prefix || getPrefix(css)
 
   // only parse if in a browserify transform
   if (typeof filename === 'string') parseCss(src, filename, prefix, options, done)


### PR DESCRIPTION
This would allow people to choose a fixed classname to be used for their sheetify modules. Most people probably won't need this, but it could be useful for projects that need to allow CSS themes to override the default stylesheet. All feedback welcome :)