### PR TITLE
Do not set options.use twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,6 @@ function parseCss (src, filename, prefix, options, done) {
   // one at the time
   // (str, str, obj, fn) -> null
   function applyTransforms (filename, src, options, done) {
-    options.use = [].concat(options.use || []).concat(options.u || [])
     mapLimit(options.use, 1, iterate, function (err) {
       if (err) return done(err)
       done(null, src)


### PR DESCRIPTION
Heey,

Noticed that plugins where running twice, using it like this:
```
browserify -t [sheetify -u sheetify-sass] index.js > bundle.js
```
Logging of `options.use` outputted `['sheetify-sass', 'sheetify-sass']`
Looks like it is set twice, which seems to cause this.
https://github.com/stackcss/sheetify/blob/master/transform.js#L25
https://github.com/stackcss/sheetify/blob/master/index.js#L85

Removed one of them.