### PR TITLE
feat(transform): support subarg syntax in transform, closes #140

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,6 @@ function parseCss (src, filename, prefix, options, done) {
   // one at the time
   // (str, str, obj, fn) -> null
   function applyTransforms (filename, src, options, done) {
-    options.transform = [].concat(options.transform || []).concat(options.t || [])
     mapLimit(options.transform, 1, iterate, function (err) {
       if (err) return done(err)
       done(null, src)

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "rimraf": "^2.5.1",
     "sheetify-cssnext": "^1.0.0",
     "standard": "^8.0.0",
+    "subarg": "^1.0.0",
     "tape": "^4.2.0"
   }
 }

--- a/test/fixtures/simple-plugin.js
+++ b/test/fixtures/simple-plugin.js
@@ -1,0 +1,3 @@
+module.exports = function (filename, source, options, done) {
+  done(null, options.replace)
+}

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,4 +1,5 @@
 const browserify = require('browserify')
+const subarg = require('subarg')
 const concat = require('concat-stream')
 const through = require('through2')
 const test = require('tape')
@@ -38,5 +39,20 @@ test('plugins', function (t) {
     function outFn () {
       return ws
     }
+  })
+
+  t.test('should support subarg syntax', function (t) {
+    const bpath = path.join(__dirname, 'fixtures/plugins-source.js')
+    const bOpts = { browserField: false }
+    const sTransform = require.resolve('./fixtures/simple-plugin')
+    const args = subarg([ '--transform', '[', sTransform, '--replace', '.test{}', ']' ])
+    browserify(bpath, bOpts)
+      .transform(sheetify, args)
+      .exclude('sheetify/insert')
+      .bundle()
+      .pipe(concat(function (bundle) {
+        t.notEqual(bundle.indexOf(`require('sheetify/insert')(".test{}")`), -1)
+        t.end()
+      }))
   })
 })

--- a/transform.js
+++ b/transform.js
@@ -24,6 +24,17 @@ function transform (filename, options) {
     out: ''
   })
 
+  opts.transform = [].concat(opts.transform || []).concat(opts.t || []).map(function (plugin) {
+    // resolve subarg syntax
+    if (typeof plugin === 'object' && Array.isArray(plugin._)) {
+      return [
+        plugin._[0],
+        plugin
+      ]
+    }
+    return plugin
+  })
+
   const bufs = []
   const transformStream = through(write, end)
   return transformStream


### PR DESCRIPTION
This makes it possible to pass options to sheetify plugins using
the browserify subarg syntax on the cli:

```bash
browserify -t [ sheetify -t [ sheetify-sass --indentedSyntax ] ]
```