### PR TITLE
Transform: support node require

### DIFF
--- a/test/fixtures/example.js
+++ b/test/fixtures/example.js
@@ -1,0 +1,1 @@
+module.exports = '.foo { color: blue; }'

--- a/test/fixtures/import-source-js.js
+++ b/test/fixtures/import-source-js.js
@@ -1,0 +1,3 @@
+const sf = require('sheetify')
+
+sf('./example.js')

--- a/test/import.js
+++ b/test/import.js
@@ -38,6 +38,35 @@ test('npm import', function (t) {
     }
   })
 
+  t.test('should import js file', function (t) {
+    t.plan(1)
+
+    const expected = require(path.join(__dirname, 'fixtures/example.js'))
+
+    const ws = concat(function (buf) {
+      const res = String(buf).trim()
+      t.equal(res, expected, 'package was imported')
+    })
+
+    const bOpts = { browserField: false }
+    const bpath = path.join(__dirname, 'fixtures/import-source-js.js')
+    browserify(bpath, bOpts)
+      .transform(sheetify)
+      .transform(function (file) {
+        return through(function (buf, enc, next) {
+          const str = buf.toString('utf8')
+          this.push(str.replace(/sheetify\/insert/, 'insert-css'))
+          next()
+        })
+      })
+      .plugin('css-extract', { out: outFn })
+      .bundle()
+
+    function outFn () {
+      return ws
+    }
+  })
+
   t.test('should emit an error on broken import', function (t) {
     t.plan(1)
 

--- a/transform.js
+++ b/transform.js
@@ -136,7 +136,7 @@ function transform (filename, options) {
   function iterate (val, done) {
     if (val.css) return handleCss(val)
 
-    if (val.filename.endsWith('.js')) {
+    if (/\.js$/.test(val.filename)) {
       delete require.cache[require.resolve(val.filename)]
       val.css = require(val.filename)
       handleCss(val)

--- a/transform.js
+++ b/transform.js
@@ -135,11 +135,18 @@ function transform (filename, options) {
   // (obj, fn) -> null
   function iterate (val, done) {
     if (val.css) return handleCss(val)
-    fs.readFile(val.filename, 'utf8', function (err, css) {
-      if (err) return done(err)
-      val.css = css
+
+    if (val.filename.endsWith('.js')) {
+      delete require.cache[require.resolve(val.filename)]
+      val.css = require(val.filename)
       handleCss(val)
-    })
+    } else {
+      fs.readFile(val.filename, 'utf8', function (err, css) {
+        if (err) return done(err)
+        val.css = css
+        handleCss(val)
+      })
+    }
 
     function handleCss (val) {
       sheetify(val.css, val.filename, val.opts, function (err, css, prefix) {


### PR DESCRIPTION
Adds support to import css from js files:

**style.js**

```js
module.exports = '.foo { color: blue; }'
```

**app.js**

```js
var css = require('sheetify')
css('./style.js')
```

## Real World

This proposed addition is particularly useful if you have a js file which generates some css. For example, [gr8](https://github.com/jongacnik/gr8) is a little function which returns a customizable set of functional css utilities. With the proposed change, you could use sheetify to insert these utilities in your app (and still get the benefits of sheetify transforms, css extraction, etc, esp when using something like bankai):

**style.js**

```js
var gr8 = require('gr8')
module.exports = gr8()
```

**app.js**

```js
var css = require('sheetify')
css('./style.js')
```

## lil Demo

Put together a tiny demo to show this all working in practice:

- [style.js](https://glitch.com/edit/#!/sheetify-node?path=style.js:1:0)
- [index.js](https://glitch.com/edit/#!/sheetify-node?path=index.js:1:0)
- [https://sheetify-node.glitch.me](https://sheetify-node.glitch.me/)

✌️