### PR TITLE
Remove unnecessary options from transform-package tests

### DIFF
--- a/test/fixtures/transform-package/package.json
+++ b/test/fixtures/transform-package/package.json
@@ -8,9 +8,5 @@
         }
       ]
     ]
-  },
-  "dependencies": {
-    "sheetify": "file:../../..",
-    "sheetify-cssnext": "^1.0.0"
   }
 }

--- a/test/transform-package.js
+++ b/test/transform-package.js
@@ -19,10 +19,9 @@ test('transform-package', function (t) {
       t.equal(res, expected, 'CSS was transformed')
     })
 
-    const bOpts = { browserField: false }
     const bpath = path.join(__dirname, 'fixtures/transform-package/source.js')
 
-    browserify(bpath, bOpts)
+    browserify(bpath)
       .transform(sheetify)
       .transform(function (file) {
         return through(function (buf, enc, next) {


### PR DESCRIPTION
Just some minor changes removing unnecessary options. I guess it's up to you whether you want these changes, but I think it's best to keep things minimal!