### PR TITLE
watch file imports

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -135,6 +135,8 @@ function transform (filename, options) {
         ? xtend(opts, staticEval(node.arguments[1]))
         : opts
 
+      transformStream.emit('file', resolvePath)
+
       const val = {
         filename: resolvePath,
         opts: iOpts,


### PR DESCRIPTION
Allows us to track imported files through `css('./file-name.css')`. Thanks!

## Refs
- https://github.com/stackcss/sheetify/issues/144
- https://github.com/choojs/bankai/issues/386