### PR TITLE
Allow transforms to return a `{ css, files }` object

### DIFF
--- a/test/fixtures/files-plugin.js
+++ b/test/fixtures/files-plugin.js
@@ -1,0 +1,6 @@
+module.exports = function (file, source, opts, done) {
+  done(null, {
+    css: '.test {}',
+    files: [opts.file]
+  })
+}

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -76,6 +76,7 @@ test('plugins', function (t) {
       .on('file', onfile)
       .on('transform', ontransform)
       .bundle(function (err, result) {
+        t.ifError(err)
         t.deepEqual(actualFiles.sort(), expectedFiles.sort())
         t.end()
       })

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -55,4 +55,38 @@ test('plugins', function (t) {
         t.end()
       }))
   })
+
+  t.test('should emit \'file\' events if transform included more files', function (t) {
+    const bpath = path.join(__dirname, 'fixtures/plugins-source.js')
+    const bOpts = { browserField: false }
+    const expectedFiles = [
+      bpath,
+      '/path/to/included/file.css'
+    ]
+    const actualFiles = []
+    browserify(bpath, bOpts)
+      .transform(sheetify, {
+        transform: [
+          [ require.resolve('./fixtures/files-plugin'), {
+            file: '/path/to/included/file.css'
+          } ]
+        ]
+      })
+      .exclude('sheetify/insert')
+      .on('file', onfile)
+      .on('transform', ontransform)
+      .bundle(function (err, result) {
+        t.deepEqual(actualFiles.sort(), expectedFiles.sort())
+        t.end()
+      })
+
+    function onfile (filename) {
+      if (actualFiles.indexOf(filename) === -1) {
+        actualFiles.push(filename)
+      }
+    }
+    function ontransform (tr) {
+      tr.on('file', onfile)
+    }
+  })
 })

--- a/transform.js
+++ b/transform.js
@@ -202,10 +202,10 @@ function transform (filename, options) {
     }
 
     function handleCss (val) {
-      sheetify(val.css, val.filename, val.opts, function (err, css, prefix) {
+      sheetify(val.css, val.filename, val.opts, function (err, result, prefix) {
         if (err) return done(err)
         const str = [
-          "((require('sheetify/insert')(" + JSON.stringify(css) + ')',
+          "((require('sheetify/insert')(" + JSON.stringify(result.css) + ')',
           ' || true) && ' + JSON.stringify(prefix) + ')'
         ].join('')
 
@@ -215,6 +215,11 @@ function transform (filename, options) {
           ? ''
           : ';'
         val.node.update(lolSemicolon + str)
+
+        result.files.forEach(function (includedFile) {
+          transformStream.emit('file', includedFile)
+        })
+
         done()
       })
     }


### PR DESCRIPTION
`'file'` events will be emitted for each file listed in `files`.

This allows watchify et al to pick up on files that were included by sheetify transforms.