### PR TITLE
Source maps! closes #62

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "css-modules"
   ],
   "dependencies": {
-    "falafel": "^2.1.0",
+    "acorn-node": "^1.3.0",
     "fast-json-parse": "^1.0.2",
     "findup": "^0.1.5",
     "insert-css": "^2.0.0",
@@ -33,6 +33,7 @@
     "static-eval": "^1.1.0",
     "style-resolve": "^1.1.0",
     "through2": "^2.0.0",
+    "transform-ast": "^2.4.0",
     "xtend": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This patch switches to transform-ast, which has an almost identical API to falafel but also generates source maps. transform-ast has a `.walk()` method that we can use to avoid having to parse the source twice just to walk it twice, so this should speed things up a bit too!