### PR TITLE
Allow specifying transforms as functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ function parseCss (src, filename, prefix, options, done) {
       const name = plugin[0]
       const opts = plugin[1] || {}
       if (typeof name === 'function') {
-        ontransform(name, opts)
+        return transformLoaded(name, opts)
       }
 
       const resolveOpts = {
@@ -110,10 +110,10 @@ function parseCss (src, filename, prefix, options, done) {
         if (err) return done(err)
 
         const transform = require(transformPath)
-        ontransform(transform, opts)
+        transformLoaded(transform, opts)
       })
 
-      function ontransform (transform, opts) {
+      function transformLoaded (transform, opts) {
         transform(filename, current.css, opts, function (err, result) {
           if (err) return next(err)
           if (typeof result === 'string') {

--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ function parseCss (src, filename, prefix, options, done) {
     // find and apply a transform to a string of css
     // (fn, fn) -> null
     function iterate (plugin, next) {
-      if (typeof plugin === 'string') {
+      if (typeof plugin === 'string' || typeof plugin === 'function') {
         plugin = [ plugin, {} ]
       } else if (!Array.isArray(plugin)) {
         return done(new Error('Plugin must be a string or array'))
@@ -99,6 +99,9 @@ function parseCss (src, filename, prefix, options, done) {
 
       const name = plugin[0]
       const opts = plugin[1] || {}
+      if (typeof name === 'function') {
+        ontransform(name, opts)
+      }
 
       const resolveOpts = {
         basedir: opts.basedir || options.basedir || process.cwd()
@@ -107,6 +110,10 @@ function parseCss (src, filename, prefix, options, done) {
         if (err) return done(err)
 
         const transform = require(transformPath)
+        ontransform(transform, opts)
+      })
+
+      function ontransform (transform, opts) {
         transform(filename, current.css, opts, function (err, result) {
           if (err) return next(err)
           if (typeof result === 'string') {
@@ -117,7 +124,7 @@ function parseCss (src, filename, prefix, options, done) {
           }
           next()
         })
-      })
+      }
     }
   }
 }

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -90,4 +90,24 @@ test('plugins', function (t) {
       tr.on('file', onfile)
     }
   })
+
+  t.test('should be allowed to be functions', function (t) {
+    const bpath = path.join(__dirname, 'fixtures/plugins-source.js')
+    const bOpts = { browserField: false }
+    browserify(bpath, bOpts)
+      .transform(sheetify, {
+        transform: [
+          function (filename, css, opts, cb) {
+            t.pass('called the transform')
+            cb(null, '.whatever{}')
+          }
+        ]
+      })
+      .exclude('sheetify/insert')
+      .bundle(function (err, result) {
+        t.ifError(err)
+        t.notEqual(result.indexOf('.whatever{}'), -1)
+        t.end()
+      })
+  })
 })


### PR DESCRIPTION
Makes these equivalent:

```js
b.transform(sheetify, {
  transform: ['sheetify-cssnext']
})
```
```js
b.transform(sheetify, {
  transform: [require('sheetify-cssnext')]
})
```

Previously, the latter would throw an error.