### PR TITLE
Handle new Bublé template string compilation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@choojs/findup": "^0.2.0",
     "acorn-node": "^1.3.0",
+    "estree-is-member-expression": "^1.0.0",
     "fast-json-parse": "^1.0.2",
     "insert-css": "^2.0.0",
     "map-limit": "0.0.1",


### PR DESCRIPTION
https://github.com/Rich-Harris/buble/pull/67 changed Bublé template strings to compile similarly to Babel ones, for spec reasons.
With this patch, the new style as well as the old style are detected correctly.