### PR TITLE
Remove npm-check-updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "from2-string": "^1.1.0",
     "istanbul": "^0.4.5",
     "jsdom": "^9.4.2",
-    "npm-check-updates": "^2.2.0",
     "rimraf": "^2.5.1",
     "sheetify-cssnext": "^2.0.1",
     "standard": "^11.0.1",


### PR DESCRIPTION
It's a big dependency (it pulls in a full npm cli install for example) and it seems like something that should be installed globally instead. It's not used by any scripts.